### PR TITLE
Correct deepmerge arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ const { config } = await octokit.config.get({
   owner,
   repo,
   path: ".github/test.yml",
-  defaults: (configs) => deepmerge([defaults, ...configs]),
+  defaults: (configs) => deepmerge.all([defaults, ...configs]),
 });
 ```
 


### PR DESCRIPTION
`merge` takes 2 single objects, `merge.all` takes an array

This confused me for awhile =/

-----
[View rendered README.md](https://github.com/timja/octokit-plugin-config/blob/patch-1/README.md)