### PR TITLE
fix: Export types

### DIFF
--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -61,7 +61,7 @@ async function main() {
         types: "dist-types/index.d.ts",
         exports: {
           ".": {
-            types: "./dist-src/index.js",
+            types: "./dist-types/index.d.ts",
             import: "./dist-src/index.js",
           },
         },


### PR DESCRIPTION
This actually exports the types. This was accidentially broken in #249.