### PR TITLE
Export all types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import { Octokit } from "@octokit/core";
 import { VERSION } from "./version.js";
 import { composeConfigGet } from "./compose-config-get.js";
 import type * as Types from "./types.js";
+export type * from "./types.js";
 
 /**
  * @param octokit Octokit instance


### PR DESCRIPTION
This helps avoid an error

>  error TS2742: The inferred type of 'ProbotOctokit' cannot be named without a reference to '../../node_modules/@probot/octokit-plugin-config/dist-types/types.js'. This is likely not portable. A type annotation is necessary.