### PR TITLE
feat: deepmerge by default

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0-development",
       "license": "MIT",
       "dependencies": {
+        "@fastify/deepmerge": "^2.0.0",
         "js-yaml": "^4.1.0"
       },
       "devDependencies": {
@@ -509,6 +510,11 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@fastify/deepmerge": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@fastify/deepmerge/-/deepmerge-2.0.0.tgz",
+      "integrity": "sha512-fsaybTGDyQ5KpPsplQqb9yKdCf2x/pbNpMNk8Tvp3rRz7lVcupKysH4b2ELMN2P4Hak1+UqTYdTj/u4FNV2p0g=="
     },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "access": "public"
   },
   "dependencies": {
+    "@fastify/deepmerge": "^2.0.0",
     "js-yaml": "^4.1.0"
   },
   "engines": {

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,7 +27,16 @@ export type GetOptions<T> = {
    * An object will be merged shallowly. Pass a function for deep merges and custom merge strategies,
    * @see https://github.com/probot/octokit-plugin-config/#merging-configuration
    */
-  defaults?: T | defaultsFunction<T>;
+  defaults?: T;
+
+  /**
+   * Custom merge function to combine multiple configurations.
+   */
+  merge?: mergeFunction<T>;
+
+  /**
+   * Branch to load configuration from
+   */
   branch?: string;
 };
 
@@ -65,4 +74,4 @@ export type ConfigFile = {
   config: Configuration | null;
 };
 
-export type defaultsFunction<T> = (files: Configuration[]) => T;
+export type mergeFunction<T> = (...configs: Configuration[]) => T;

--- a/test/__snapshots__/get.test.ts.snap
+++ b/test/__snapshots__/get.test.ts.snap
@@ -209,6 +209,102 @@ exports[`octokit.config.get > _extends: base:test.yml > result 1`] = `
 }
 `;
 
+exports[`octokit.config.get > _extends: change to shallow copy with Object.assign > result 1`] = `
+{
+  "config": {
+    "repository": {
+      "allow_squash_merge": false,
+    },
+  },
+  "files": [
+    {
+      "config": {
+        "repository": {
+          "allow_squash_merge": false,
+        },
+      },
+      "owner": "org",
+      "path": ".github/settings.yml",
+      "repo": "repo-c",
+      "url": "https://api.github.com/repos/org/repo-c/contents/.github%2Fsettings.yml",
+    },
+    {
+      "config": {
+        "repository": {
+          "allow_rebase_merge": false,
+        },
+      },
+      "owner": "org",
+      "path": ".github/settings.yml",
+      "repo": "repo-b",
+      "url": "https://api.github.com/repos/org/repo-b/contents/.github%2Fsettings.yml",
+    },
+    {
+      "config": {
+        "repository": {
+          "allow_merge_commit": true,
+          "allow_rebase_merge": true,
+          "allow_squash_merge": true,
+        },
+      },
+      "owner": "org",
+      "path": ".github/settings.yml",
+      "repo": "github-settings",
+      "url": "https://api.github.com/repos/org/github-settings/contents/.github%2Fsettings.yml",
+    },
+  ],
+}
+`;
+
+exports[`octokit.config.get > _extends: deepmerge > result 1`] = `
+{
+  "config": {
+    "repository": {
+      "allow_merge_commit": true,
+      "allow_rebase_merge": false,
+      "allow_squash_merge": false,
+    },
+  },
+  "files": [
+    {
+      "config": {
+        "repository": {
+          "allow_squash_merge": false,
+        },
+      },
+      "owner": "org",
+      "path": ".github/settings.yml",
+      "repo": "repo-c",
+      "url": "https://api.github.com/repos/org/repo-c/contents/.github%2Fsettings.yml",
+    },
+    {
+      "config": {
+        "repository": {
+          "allow_rebase_merge": false,
+        },
+      },
+      "owner": "org",
+      "path": ".github/settings.yml",
+      "repo": "repo-b",
+      "url": "https://api.github.com/repos/org/repo-b/contents/.github%2Fsettings.yml",
+    },
+    {
+      "config": {
+        "repository": {
+          "allow_merge_commit": true,
+          "allow_rebase_merge": true,
+          "allow_squash_merge": true,
+        },
+      },
+      "owner": "org",
+      "path": ".github/settings.yml",
+      "repo": "github-settings",
+      "url": "https://api.github.com/repos/org/github-settings/contents/.github%2Fsettings.yml",
+    },
+  ],
+}
+`;
+
 exports[`octokit.config.get > _extends: other-owner/base > result 1`] = `
 {
   "config": {


### PR DESCRIPTION
BREAKING CHANGE: Use @fastify/deepmerge to deepmerge configurations
BREAKING CHANGE: defaults option does not accept a merge function anymore
BREAKING CHANGE: adding new merge option, which can be used to override the the default merge strategy